### PR TITLE
Fix enum usage when compiling in C

### DIFF
--- a/include/CNZSL/DebugLevel.h
+++ b/include/CNZSL/DebugLevel.h
@@ -9,7 +9,7 @@
 #ifndef CNZSL_DEBUGLEVEL_H
 #define CNZSL_DEBUGLEVEL_H
 
-enum nzslDebugLevel
+typedef enum
 {
 	NZSL_DEBUG_NONE,
 
@@ -18,6 +18,6 @@ enum nzslDebugLevel
 	NZSL_DEBUG_REGULAR,
 
 	NZSL_DEBUG_MAX_ENUM = 0x7FFFFFFF
-};
+} nzslDebugLevel;
 
 #endif /* CNZSL_DEBUGLEVEL_H */

--- a/include/CNZSL/ShaderStageType.h
+++ b/include/CNZSL/ShaderStageType.h
@@ -9,13 +9,13 @@
 #ifndef CNZSL_SHADERSTAGETYPE_H
 #define CNZSL_SHADERSTAGETYPE_H
 
-enum nzslShaderStageType
+typedef enum
 {
 	NZSL_STAGE_COMPUTE,
 	NZSL_STAGE_FRAGMENT,
 	NZSL_STAGE_VERTEX,
 
 	NZSL_STAGE_MAX_ENUM = 0x7FFFFFFF
-};
+} nzslShaderStageType;
 
 #endif /* CNZSL_SHADERSTAGETYPE_H */


### PR DESCRIPTION
The C compiler complains on some enums