### PR TITLE
Add target attribute

### DIFF
--- a/include/NZSL/Ast/Compare.inl
+++ b/include/NZSL/Ast/Compare.inl
@@ -834,6 +834,12 @@ namespace nzsl::Ast
 
 	bool Compare(const ScopedStatement& lhs, const ScopedStatement& rhs, const ComparisonParams& params)
 	{
+		if (!Compare(lhs.targetType, rhs.targetType, params))
+			return false;
+
+		if (!Compare(lhs.targetVersion, rhs.targetVersion, params))
+			return false;
+
 		if (!Compare(lhs.statement, rhs.statement, params))
 			return false;
 

--- a/include/NZSL/Ast/Enums.hpp
+++ b/include/NZSL/Ast/Enums.hpp
@@ -47,6 +47,7 @@ namespace nzsl::Ast
 		Tag                = 16, //< Tag (external block and external var only) - has argument string
 		Unroll             = 11, //< Unroll (for/for each only) - has argument mode
 		Workgroup          = 18, //< Work group size (function only) - has arguments X, Y, Z
+		Target             = 20, //< 
 	};
 
 	enum class BinaryType
@@ -267,6 +268,13 @@ namespace nzsl::Ast
 		LogicalNot = 0, //< !v
 		Minus      = 1, //< -v
 		Plus       = 2, //< +v
+	};
+
+	enum class TargetType
+	{
+		GLSL = 0,
+		GLES = 1,
+		SPIRV = 3,
 	};
 }
 

--- a/include/NZSL/Ast/Enums.hpp
+++ b/include/NZSL/Ast/Enums.hpp
@@ -26,7 +26,7 @@ namespace nzsl::Ast
 
 	enum class AttributeType
 	{
-		// Next free ID: 20
+		// Next free ID: 21
 		AutoBinding        = 17, //< Incremental binding index (external block only)
 		Author             = 12, //< Module author (module statement only) - has argument version string
 		Binding            =  0, //< Binding (external var only) - has argument index
@@ -47,7 +47,7 @@ namespace nzsl::Ast
 		Tag                = 16, //< Tag (external block and external var only) - has argument string
 		Unroll             = 11, //< Unroll (for/for each only) - has argument mode
 		Workgroup          = 18, //< Work group size (function only) - has arguments X, Y, Z
-		Target             = 20, //< 
+		Target             = 20, //< Mark a scope as target specific - has arguments target string, version (optional)
 	};
 
 	enum class BinaryType

--- a/include/NZSL/Ast/Nodes.hpp
+++ b/include/NZSL/Ast/Nodes.hpp
@@ -526,6 +526,8 @@ namespace nzsl::Ast
 		NodeType GetType() const override;
 		void Visit(StatementVisitor& visitor) override;
 
+		ExpressionValue<TargetType> targetType;
+		ExpressionValue<std::uint32_t> targetVersion;
 		StatementPtr statement;
 	};
 

--- a/include/NZSL/Lang/ErrorList.hpp
+++ b/include/NZSL/Lang/ErrorList.hpp
@@ -39,6 +39,7 @@ NZSL_SHADERLANG_PARSER_ERROR(AttributeInvalidParameter, "invalid parameter {} fo
 NZSL_SHADERLANG_PARSER_ERROR(AttributeMultipleUnique, "attribute {} can only be present once", Ast::AttributeType)
 NZSL_SHADERLANG_PARSER_ERROR(AttributeParameterIdentifier, "attribute {} parameter can only be an identifier", Ast::AttributeType)
 NZSL_SHADERLANG_PARSER_ERROR(AttributeUnexpectedParameterCount, "attribute {} expects {} arguments, got {}", Ast::AttributeType, std::size_t, std::size_t)
+NZSL_SHADERLANG_PARSER_ERROR(AttributeInvalidTargetVersion, "invalid target version {} for target {}", std::int32_t, std::string)
 NZSL_SHADERLANG_PARSER_ERROR(ExpectedToken, "expected token {}, got {}", TokenType, TokenType)
 NZSL_SHADERLANG_PARSER_ERROR(DuplicateIdentifier, "duplicate identifier")
 NZSL_SHADERLANG_PARSER_ERROR(DuplicateModule, "duplicate module")

--- a/include/NZSL/LangWriter.hpp
+++ b/include/NZSL/LangWriter.hpp
@@ -58,6 +58,7 @@ namespace nzsl
 			struct TagAttribute;
 			struct UnrollAttribute;
 			struct WorkgroupAttribute;
+			struct TargetAttribute;
 
 			void Append(const Ast::AliasType& type);
 			void Append(const Ast::ArrayType& type);
@@ -104,6 +105,7 @@ namespace nzsl
 			void AppendAttribute(TagAttribute attribute);
 			void AppendAttribute(UnrollAttribute attribute);
 			void AppendAttribute(WorkgroupAttribute attribute);
+			void AppendAttribute(TargetAttribute attribute);
 			void AppendComment(std::string_view section);
 			void AppendCommentSection(std::string_view section);
 			void AppendHeader();

--- a/include/NZSL/Parser.hpp
+++ b/include/NZSL/Parser.hpp
@@ -31,6 +31,7 @@ namespace nzsl
 			static std::string_view ToString(Ast::LoopUnroll loopUnroll);
 			static std::string_view ToString(Ast::MemoryLayout memoryLayout);
 			static std::string_view ToString(Ast::ModuleFeature moduleFeature);
+			static std::string_view ToString(Ast::TargetType targetType);
 			static std::string_view ToString(ShaderStageType shaderStage);
 
 		private:
@@ -74,7 +75,7 @@ namespace nzsl
 			Ast::StatementPtr ParseReturnStatement();
 			Ast::StatementPtr ParseRootStatement(std::vector<Attribute> attributes = {});
 			Ast::StatementPtr ParseSingleStatement();
-			Ast::StatementPtr ParseStatement();
+			Ast::StatementPtr ParseStatement(std::vector<Attribute> attributes = {});
 			std::vector<Ast::StatementPtr> ParseStatementList(SourceLocation* sourceLocation);
 			Ast::StatementPtr ParseStructDeclaration(std::vector<Attribute> attributes = {});
 			Ast::StatementPtr ParseVariableDeclaration();

--- a/src/NZSL/Ast/AstSerializer.cpp
+++ b/src/NZSL/Ast/AstSerializer.cpp
@@ -504,6 +504,8 @@ namespace nzsl::Ast
 
 	void SerializerBase::Serialize(ScopedStatement& node)
 	{
+		ExprValue(node.targetType);
+		ExprValue(node.targetVersion);
 		Node(node.statement);
 	}
 

--- a/src/NZSL/Ast/Cloner.cpp
+++ b/src/NZSL/Ast/Cloner.cpp
@@ -332,6 +332,8 @@ namespace nzsl::Ast
 	StatementPtr Cloner::Clone(ScopedStatement& node)
 	{
 		auto clone = std::make_unique<ScopedStatement>();
+		clone->targetType = Clone(node.targetType);
+		clone->targetVersion = Clone(node.targetVersion);
 		clone->statement = CloneStatement(node.statement);
 
 		clone->sourceLocation = node.sourceLocation;

--- a/src/NZSL/GlslWriter.cpp
+++ b/src/NZSL/GlslWriter.cpp
@@ -2703,6 +2703,20 @@ namespace nzsl
 
 	void GlslWriter::Visit(Ast::ScopedStatement& node)
 	{
+		if (node.targetType.IsResultingValue())
+		{
+			unsigned int glVersion = m_environment.glMajorVersion * 100 + m_environment.glMinorVersion * 10;
+			auto targetType = node.targetType.GetResultingValue();
+			std::uint32_t targetVersion = 0;
+			if (node.targetVersion.IsResultingValue())
+				targetVersion = node.targetVersion.GetResultingValue();
+
+			const auto isGLSL = !m_environment.glES && targetType == Ast::TargetType::GLSL;
+			const auto isGLES = m_environment.glES && targetType == Ast::TargetType::GLES;
+			if (!((isGLSL || isGLES) && targetVersion <= glVersion))
+				return;
+		}
+
 		EnterScope();
 		node.statement->Visit(*this);
 		LeaveScope(true);

--- a/src/NZSL/Lang/Errors.cpp
+++ b/src/NZSL/Lang/Errors.cpp
@@ -84,6 +84,19 @@ struct fmt::formatter<nzsl::TokenType> : formatter<string_view>
 	}
 };
 
+template<>
+struct fmt::formatter<nzsl::Ast::TargetType> : formatter<string_view>
+{
+	template<typename FormatContext>
+	auto format(const nzsl::Ast::TargetType& p, FormatContext& ctx) const -> decltype(ctx.out())
+	{
+		auto it = nzsl::LangData::s_targets.find(p);
+		assert(it != nzsl::LangData::s_targets.end());
+
+		return formatter<string_view>::format(it->second.identifier, ctx);
+	}
+};
+
 namespace nzsl
 {
 	std::string_view ToString(ErrorCategory errorCategory)

--- a/src/NZSL/Lang/LangData.hpp
+++ b/src/NZSL/Lang/LangData.hpp
@@ -43,7 +43,8 @@ namespace nzsl::LangData
 		{ Ast::AttributeType::Set,                { "set" } },
 		{ Ast::AttributeType::Tag,                { "tag" } },
 		{ Ast::AttributeType::Unroll,             { "unroll" } },
-		{ Ast::AttributeType::Workgroup,          { "workgroup" } }
+		{ Ast::AttributeType::Workgroup,          { "workgroup" } },
+		{ Ast::AttributeType::Target,             { "target" } }
 	});
 
 	struct BuiltinData
@@ -258,6 +259,17 @@ namespace nzsl::LangData
 		{ Ast::LoopUnroll::Always, { "always" } },
 		{ Ast::LoopUnroll::Hint,   { "hint" } },
 		{ Ast::LoopUnroll::Never,  { "never" } }
+	});
+
+	struct TargetData
+	{
+		std::string_view identifier;
+	};
+
+	constexpr auto s_targets = frozen::make_unordered_map<Ast::TargetType, TargetData>({
+		{ Ast::TargetType::GLSL, { "glsl" } },
+		{ Ast::TargetType::GLES, { "gles" } },
+		{ Ast::TargetType::SPIRV, { "spirv" } },
 	});
 }
 

--- a/src/NZSL/Parser.cpp
+++ b/src/NZSL/Parser.cpp
@@ -1321,6 +1321,8 @@ namespace nzsl
 
 	Ast::StatementPtr Parser::ParseStatement(std::vector<Attribute> attributes)
 	{
+		NAZARA_USE_ANONYMOUS_NAMESPACE
+
 		if (Peek().type == TokenType::OpenCurlyBracket)
 		{
 			auto multiStatement = ShaderBuilder::MultiStatement();

--- a/src/NZSL/SpirV/SpirvAstVisitor.cpp
+++ b/src/NZSL/SpirV/SpirvAstVisitor.cpp
@@ -1031,6 +1031,19 @@ namespace nzsl
 
 	void SpirvAstVisitor::Visit(Ast::ScopedStatement& node)
 	{
+		if (node.targetType.IsResultingValue())
+		{
+			unsigned int spirvVersion = m_writer.m_environment.spvMajorVersion * 100 + m_writer.m_environment.spvMinorVersion * 10;
+			auto targetType = node.targetType.GetResultingValue();
+			std::uint32_t targetVersion = 0;
+			if (node.targetVersion.IsResultingValue())
+				targetVersion = node.targetVersion.GetResultingValue();
+
+			const auto isSPIRV = targetType == Ast::TargetType::SPIRV;
+			if (!(isSPIRV && targetVersion <= spirvVersion))
+				return;
+		}
+
 		node.statement->Visit(*this);
 	}
 


### PR DESCRIPTION
This pull request introduces a new attribute for `ScopedStatement` called `target`. Target attribute allows programmer to write target (and optionally, it's version) specific shader code. Here is how it looks:
```rs
[entry(frag)]
fn main()
{
        [target(spirv)]
        {
                // Do some spir-v operations thats only valid on spir-v.
        }
        
        // Contents of this scope will be discarded for targets before SPIR-V 1.5.
        [target(spirv, 150)]
        {
                // Do some spir-v operations thats only valid on spir-v 1.5.
        }

        [target(glsl)]
        {
                // ...
        }

        [target(gles)]
        {
                // ...
        }
}
```