### PR TITLE
Add support for implicit arrays and implicit matrices

### DIFF
--- a/include/NZSL/Ast/ExpressionType.hpp
+++ b/include/NZSL/Ast/ExpressionType.hpp
@@ -110,6 +110,12 @@ namespace nzsl::Ast
 		inline bool operator!=(const FunctionType& rhs) const;
 	};
 
+	struct ImplicitArrayType
+	{
+		inline bool operator==(const ImplicitArrayType& rhs) const;
+		inline bool operator!=(const ImplicitArrayType& rhs) const;
+	};
+
 	struct ImplicitVectorType
 	{
 		std::size_t componentCount;
@@ -247,7 +253,7 @@ namespace nzsl::Ast
 		inline bool operator!=(const PushConstantType& rhs) const;
 	};
 
-	using ExpressionType = std::variant<NoType, AliasType, ArrayType, DynArrayType, FunctionType, ImplicitVectorType, IntrinsicFunctionType, MatrixType, MethodType, ModuleType, NamedExternalBlockType, PrimitiveType, PushConstantType, SamplerType, StorageType, StructType, TextureType, Type, UniformType, VectorType>;
+	using ExpressionType = std::variant<NoType, AliasType, ArrayType, DynArrayType, FunctionType, ImplicitArrayType, ImplicitVectorType, IntrinsicFunctionType, MatrixType, MethodType, ModuleType, NamedExternalBlockType, PrimitiveType, PushConstantType, SamplerType, StorageType, StructType, TextureType, Type, UniformType, VectorType>;
 
 	struct ContainedType
 	{
@@ -280,6 +286,7 @@ namespace nzsl::Ast
 	inline bool IsDynArrayType(const ExpressionType& type);
 	inline bool IsFunctionType(const ExpressionType& type);
 	inline bool IsImplicitType(const ExpressionType& type);
+	inline bool IsImplicitArrayType(const ExpressionType& type);
 	inline bool IsImplicitVectorType(const ExpressionType& type);
 	inline bool IsIntrinsicFunctionType(const ExpressionType& type);
 	inline bool IsMatrixType(const ExpressionType& type);

--- a/include/NZSL/Ast/ExpressionType.hpp
+++ b/include/NZSL/Ast/ExpressionType.hpp
@@ -116,6 +116,15 @@ namespace nzsl::Ast
 		inline bool operator!=(const ImplicitArrayType& rhs) const;
 	};
 
+	struct ImplicitMatrixType
+	{
+		std::size_t columnCount;
+		std::size_t rowCount;
+
+		inline bool operator==(const ImplicitMatrixType& rhs) const;
+		inline bool operator!=(const ImplicitMatrixType& rhs) const;
+	};
+
 	struct ImplicitVectorType
 	{
 		std::size_t componentCount;
@@ -253,7 +262,7 @@ namespace nzsl::Ast
 		inline bool operator!=(const PushConstantType& rhs) const;
 	};
 
-	using ExpressionType = std::variant<NoType, AliasType, ArrayType, DynArrayType, FunctionType, ImplicitArrayType, ImplicitVectorType, IntrinsicFunctionType, MatrixType, MethodType, ModuleType, NamedExternalBlockType, PrimitiveType, PushConstantType, SamplerType, StorageType, StructType, TextureType, Type, UniformType, VectorType>;
+	using ExpressionType = std::variant<NoType, AliasType, ArrayType, DynArrayType, FunctionType, ImplicitArrayType, ImplicitMatrixType, ImplicitVectorType, IntrinsicFunctionType, MatrixType, MethodType, ModuleType, NamedExternalBlockType, PrimitiveType, PushConstantType, SamplerType, StorageType, StructType, TextureType, Type, UniformType, VectorType>;
 
 	struct ContainedType
 	{
@@ -287,6 +296,7 @@ namespace nzsl::Ast
 	inline bool IsFunctionType(const ExpressionType& type);
 	inline bool IsImplicitType(const ExpressionType& type);
 	inline bool IsImplicitArrayType(const ExpressionType& type);
+	inline bool IsImplicitMatrixType(const ExpressionType& type);
 	inline bool IsImplicitVectorType(const ExpressionType& type);
 	inline bool IsIntrinsicFunctionType(const ExpressionType& type);
 	inline bool IsMatrixType(const ExpressionType& type);
@@ -347,6 +357,8 @@ namespace nzsl::Ast
 
 	NZSL_API std::string ToString(const AliasType& type, const Stringifier& stringifier = {});
 	NZSL_API std::string ToString(const ArrayType& type, const Stringifier& stringifier = {});
+	NZSL_API std::string ToString(const ImplicitArrayType& type, const Stringifier& stringifier = {});
+	NZSL_API std::string ToString(const ImplicitMatrixType& type, const Stringifier& stringifier = {});
 	NZSL_API std::string ToString(const ImplicitVectorType& type, const Stringifier& stringifier = {});
 	NZSL_API std::string ToString(const DynArrayType& type, const Stringifier& stringifier = {});
 	NZSL_API std::string ToString(const ExpressionType& type, const Stringifier& stringifier = {});

--- a/include/NZSL/Ast/ExpressionType.inl
+++ b/include/NZSL/Ast/ExpressionType.inl
@@ -100,6 +100,17 @@ namespace nzsl::Ast
 	}
 
 
+	inline bool ImplicitArrayType::operator==(const ImplicitArrayType& /*rhs*/) const
+	{
+		return true;
+	}
+
+	inline bool ImplicitArrayType::operator!=(const ImplicitArrayType& rhs) const
+	{
+		return !operator==(rhs);
+	}
+
+
 	inline bool ImplicitVectorType::operator==(const ImplicitVectorType& rhs) const
 	{
 		return componentCount == rhs.componentCount;
@@ -270,7 +281,12 @@ namespace nzsl::Ast
 
 	inline bool IsImplicitType(const ExpressionType& type)
 	{
-		return IsImplicitVectorType(type);
+		return IsImplicitArrayType(type) || IsImplicitVectorType(type);
+	}
+
+	inline bool IsImplicitArrayType(const ExpressionType& type)
+	{
+		return std::holds_alternative<ImplicitArrayType>(type);
 	}
 
 	inline bool IsImplicitVectorType(const ExpressionType& type)
@@ -560,6 +576,15 @@ namespace std
 		std::size_t operator()(const nzsl::Ast::FunctionType& functionType) const
 		{
 			return Nz::HashCombine(functionType.funcIndex);
+		}
+	};
+
+	template<>
+	struct hash<nzsl::Ast::ImplicitArrayType>
+	{
+		std::size_t operator()(const nzsl::Ast::ImplicitArrayType& /*arrayType*/) const
+		{
+			return 1;
 		}
 	};
 

--- a/include/NZSL/Ast/ExpressionType.inl
+++ b/include/NZSL/Ast/ExpressionType.inl
@@ -111,6 +111,17 @@ namespace nzsl::Ast
 	}
 
 
+	inline bool ImplicitMatrixType::operator==(const ImplicitMatrixType& rhs) const
+	{
+		return columnCount == rhs.columnCount && rowCount && rhs.rowCount;
+	}
+
+	inline bool ImplicitMatrixType::operator!=(const ImplicitMatrixType& rhs) const
+	{
+		return !operator==(rhs);
+	}
+
+
 	inline bool ImplicitVectorType::operator==(const ImplicitVectorType& rhs) const
 	{
 		return componentCount == rhs.componentCount;
@@ -281,12 +292,17 @@ namespace nzsl::Ast
 
 	inline bool IsImplicitType(const ExpressionType& type)
 	{
-		return IsImplicitArrayType(type) || IsImplicitVectorType(type);
+		return IsImplicitArrayType(type) || IsImplicitMatrixType(type) || IsImplicitVectorType(type);
 	}
 
 	inline bool IsImplicitArrayType(const ExpressionType& type)
 	{
 		return std::holds_alternative<ImplicitArrayType>(type);
+	}
+
+	inline bool IsImplicitMatrixType(const ExpressionType& type)
+	{
+		return std::holds_alternative<ImplicitMatrixType>(type);
 	}
 
 	inline bool IsImplicitVectorType(const ExpressionType& type)
@@ -585,6 +601,15 @@ namespace std
 		std::size_t operator()(const nzsl::Ast::ImplicitArrayType& /*arrayType*/) const
 		{
 			return 1;
+		}
+	};
+
+	template<>
+	struct hash<nzsl::Ast::ImplicitMatrixType>
+	{
+		std::size_t operator()(const nzsl::Ast::ImplicitMatrixType& matrixType) const
+		{
+			return Nz::HashCombine(matrixType.columnCount, matrixType.rowCount);
 		}
 	};
 

--- a/include/NZSL/Ast/Transformations/LiteralTransformer.hpp
+++ b/include/NZSL/Ast/Transformations/LiteralTransformer.hpp
@@ -31,7 +31,9 @@ namespace nzsl::Ast
 
 			void FinishExpressionHandling() override;
 
-			bool ResolveLiteral(ExpressionPtr& expression, std::optional<ExpressionType> referenceType, const SourceLocation& sourceLocation) const;
+			bool ResolveLiteral(ExpressionPtr& expression, const std::optional<ExpressionType>& referenceType, const SourceLocation& sourceLocation) const;
+			ConstantArrayValue ResolveLiteral(const ExpressionType& resolvedExprType, const ConstantArrayValue& constantValues, const std::optional<ExpressionType>& referenceType, const SourceLocation& sourceLocation) const;
+			ConstantSingleValue ResolveLiteral(const ExpressionType& resolvedExprType, const ConstantSingleValue& constantValue, const std::optional<ExpressionType>& referenceType, const SourceLocation& sourceLocation) const;
 
 			ExpressionTransformation Transform(AccessIndexExpression&& accessIndexExpr) override;
 			ExpressionTransformation Transform(AssignExpression&& assignExpr) override;

--- a/include/NZSL/Ast/Transformations/ResolveTransformer.hpp
+++ b/include/NZSL/Ast/Transformations/ResolveTransformer.hpp
@@ -83,6 +83,7 @@ namespace nzsl::Ast
 
 			const TransformerContext::Identifier* ResolveAliasIdentifier(const TransformerContext::Identifier* identifier, const SourceLocation& sourceLocation) const;
 			void ResolveFunctions();
+			ExpressionType ResolveImplicitType(const ExpressionType& expressionType);
 			std::size_t ResolveStructIndex(const ExpressionType& exprType, const SourceLocation& sourceLocation);
 			ExpressionType ResolveType(const ExpressionType& exprType, bool resolveAlias, const SourceLocation& sourceLocation);
 			std::optional<ExpressionType> ResolveTypeExpr(ExpressionValue<ExpressionType>& exprTypeValue, bool resolveAlias, const SourceLocation& sourceLocation);

--- a/include/NZSL/Ast/Utils.hpp
+++ b/include/NZSL/Ast/Utils.hpp
@@ -83,7 +83,7 @@ namespace nzsl::Ast
 	NZSL_API Expression& MandatoryExpr(const ExpressionPtr& node, const SourceLocation& sourceLocation);
 	NZSL_API Statement& MandatoryStatement(const StatementPtr& node, const SourceLocation& sourceLocation);
 
-	NZSL_API std::optional<ExpressionType> ResolveLiteralType(const ExpressionType& expressionType, std::optional<ExpressionType> referenceType, const SourceLocation& sourceLocation);
+	NZSL_API std::optional<ExpressionType> ResolveLiteralType(const ExpressionType& expressionType, const std::optional<ExpressionType>& referenceType, const SourceLocation& sourceLocation);
 
 	NZSL_API StatementPtr Unscope(StatementPtr&& statement);
 

--- a/include/NZSL/GlslWriter.hpp
+++ b/include/NZSL/GlslWriter.hpp
@@ -80,6 +80,7 @@ namespace nzsl
 			void Append(const Ast::ExpressionValue<Ast::ExpressionType>& type);
 			void Append(const Ast::FunctionType& functionType);
 			void Append(const Ast::ImplicitArrayType& type);
+			void Append(const Ast::ImplicitMatrixType& type);
 			void Append(const Ast::ImplicitVectorType& type);
 			void Append(Ast::InterpolationQualifier interpolation);
 			void Append(const Ast::IntrinsicFunctionType& intrinsicFunctionType);

--- a/include/NZSL/GlslWriter.hpp
+++ b/include/NZSL/GlslWriter.hpp
@@ -79,6 +79,7 @@ namespace nzsl
 			void Append(const Ast::ExpressionType& type);
 			void Append(const Ast::ExpressionValue<Ast::ExpressionType>& type);
 			void Append(const Ast::FunctionType& functionType);
+			void Append(const Ast::ImplicitArrayType& type);
 			void Append(const Ast::ImplicitVectorType& type);
 			void Append(Ast::InterpolationQualifier interpolation);
 			void Append(const Ast::IntrinsicFunctionType& intrinsicFunctionType);

--- a/include/NZSL/LangWriter.hpp
+++ b/include/NZSL/LangWriter.hpp
@@ -66,6 +66,7 @@ namespace nzsl
 			void Append(const Ast::ExpressionValue<Ast::ExpressionType>& type);
 			void Append(const Ast::FunctionType& functionType);
 			void Append(const Ast::ImplicitArrayType& type);
+			void Append(const Ast::ImplicitMatrixType& type);
 			void Append(const Ast::ImplicitVectorType& type);
 			void Append(const Ast::IntrinsicFunctionType& intrinsicFunctionType);
 			void Append(const Ast::MatrixType& matrixType);

--- a/include/NZSL/LangWriter.hpp
+++ b/include/NZSL/LangWriter.hpp
@@ -65,6 +65,7 @@ namespace nzsl
 			void Append(const Ast::ExpressionType& type);
 			void Append(const Ast::ExpressionValue<Ast::ExpressionType>& type);
 			void Append(const Ast::FunctionType& functionType);
+			void Append(const Ast::ImplicitArrayType& type);
 			void Append(const Ast::ImplicitVectorType& type);
 			void Append(const Ast::IntrinsicFunctionType& intrinsicFunctionType);
 			void Append(const Ast::MatrixType& matrixType);

--- a/src/NZSL/Ast/AstSerializer.cpp
+++ b/src/NZSL/Ast/AstSerializer.cpp
@@ -786,6 +786,10 @@ namespace nzsl::Ast
 				m_serializer.Serialize(std::uint8_t(20));
 				SizeT(arg.componentCount);
 			}
+			else if constexpr (std::is_same_v<T, ImplicitArrayType>)
+			{
+				m_serializer.Serialize(std::uint8_t(21));
+			}
 			else
 				static_assert(Nz::AlwaysFalse<T>(), "non-exhaustive visitor");
 		}, type);
@@ -1236,7 +1240,7 @@ NAZARA_WARNING_GCC_DISABLE("-Wmaybe-uninitialized")
 				break;
 			}
 
-			case 20: //< DeducedVectorType
+			case 20: //< ImplicitVectorType
 			{
 				std::size_t componentCount;
 				SizeT(componentCount);
@@ -1246,6 +1250,10 @@ NAZARA_WARNING_GCC_DISABLE("-Wmaybe-uninitialized")
 				};
 				break;
 			}
+
+			case 21: //< ImplicitArray
+				type = ImplicitArrayType{};
+				break;
 
 			default:
 				throw std::runtime_error("unexpected type index " + std::to_string(typeIndex));

--- a/src/NZSL/Ast/AstSerializer.cpp
+++ b/src/NZSL/Ast/AstSerializer.cpp
@@ -790,6 +790,12 @@ namespace nzsl::Ast
 			{
 				m_serializer.Serialize(std::uint8_t(21));
 			}
+			else if constexpr (std::is_same_v<T, ImplicitMatrixType>)
+			{
+				m_serializer.Serialize(std::uint8_t(22));
+				SizeT(arg.columnCount);
+				SizeT(arg.rowCount);
+			}
 			else
 				static_assert(Nz::AlwaysFalse<T>(), "non-exhaustive visitor");
 		}, type);
@@ -1254,6 +1260,19 @@ NAZARA_WARNING_GCC_DISABLE("-Wmaybe-uninitialized")
 			case 21: //< ImplicitArray
 				type = ImplicitArrayType{};
 				break;
+
+			case 22: //< ImplicitMatrixType
+			{
+				std::size_t columnCount;
+				std::size_t rowCount;
+				SizeT(columnCount);
+				SizeT(rowCount);
+
+				type = ImplicitMatrixType{
+					columnCount, rowCount
+				};
+				break;
+			}
 
 			default:
 				throw std::runtime_error("unexpected type index " + std::to_string(typeIndex));

--- a/src/NZSL/Ast/ExpressionType.cpp
+++ b/src/NZSL/Ast/ExpressionType.cpp
@@ -350,7 +350,7 @@ namespace nzsl::Ast
 			return fmt::format("array[{}]", ToString(type.InnerType(), stringifier));
 	}
 
-	std::string ToString(const ImplicitArrayType& type, const Stringifier& /*stringifier*/)
+	std::string ToString(const ImplicitArrayType& /*type*/, const Stringifier& /*stringifier*/)
 	{
 		return "array";
 	}

--- a/src/NZSL/Ast/ExpressionType.cpp
+++ b/src/NZSL/Ast/ExpressionType.cpp
@@ -292,6 +292,7 @@ namespace nzsl::Ast
 				return ResolveStructIndex(arg);
 			else if constexpr (std::is_same_v<T, NoType> ||
 			                   std::is_same_v<T, ArrayType> ||
+			                   std::is_same_v<T, ImplicitArrayType> ||
 			                   std::is_same_v<T, ImplicitVectorType> ||
 			                   std::is_same_v<T, DynArrayType> ||
 			                   std::is_same_v<T, FunctionType> ||
@@ -347,6 +348,11 @@ namespace nzsl::Ast
 			return fmt::format("array[{}, {}]", ToString(type.InnerType(), stringifier), type.length);
 		else
 			return fmt::format("array[{}]", ToString(type.InnerType(), stringifier));
+	}
+
+	std::string ToString(const ImplicitArrayType& type, const Stringifier& /*stringifier*/)
+	{
+		return "array";
 	}
 
 	std::string ToString(const ImplicitVectorType& type, const Stringifier& /*stringifier*/)

--- a/src/NZSL/Ast/ExpressionType.cpp
+++ b/src/NZSL/Ast/ExpressionType.cpp
@@ -293,6 +293,7 @@ namespace nzsl::Ast
 			else if constexpr (std::is_same_v<T, NoType> ||
 			                   std::is_same_v<T, ArrayType> ||
 			                   std::is_same_v<T, ImplicitArrayType> ||
+			                   std::is_same_v<T, ImplicitMatrixType> ||
 			                   std::is_same_v<T, ImplicitVectorType> ||
 			                   std::is_same_v<T, DynArrayType> ||
 			                   std::is_same_v<T, FunctionType> ||
@@ -353,6 +354,14 @@ namespace nzsl::Ast
 	std::string ToString(const ImplicitArrayType& /*type*/, const Stringifier& /*stringifier*/)
 	{
 		return "array";
+	}
+
+	std::string ToString(const ImplicitMatrixType& type, const Stringifier& /*stringifier*/)
+	{
+		if (type.columnCount == type.rowCount)
+			return fmt::format("mat{}", type.columnCount);
+		else
+			return fmt::format("mat{}x{}", type.columnCount, type.rowCount);
 	}
 
 	std::string ToString(const ImplicitVectorType& type, const Stringifier& /*stringifier*/)

--- a/src/NZSL/Ast/Transformations/ResolveTransformer.cpp
+++ b/src/NZSL/Ast/Transformations/ResolveTransformer.cpp
@@ -731,9 +731,12 @@ namespace nzsl::Ast
 					name = fmt::format("mat{}x{}", columnCount, rowCount);
 
 				RegisterPartialType(std::move(name), PartialType{
-					{ TypeParameterCategory::PrimitiveType }, {},
+					{}, { TypeParameterCategory::PrimitiveType },
 					[=](const TypeParameter* parameters, [[maybe_unused]] std::size_t parameterCount, const SourceLocation& sourceLocation) -> ExpressionType
 					{
+						if (parameterCount == 0)
+							return ImplicitMatrixType{ columnCount, rowCount };
+
 						assert(parameterCount == 1);
 						assert(std::holds_alternative<ExpressionType>(*parameters));
 
@@ -761,18 +764,16 @@ namespace nzsl::Ast
 				{
 					if (parameterCount == 0)
 						return ImplicitVectorType{ componentCount };
-					else
-					{
-						assert(parameterCount == 1);
-						assert(std::holds_alternative<ExpressionType>(*parameters));
 
-						const ExpressionType& exprType = std::get<ExpressionType>(*parameters);
-						assert(IsPrimitiveType(exprType));
+					assert(parameterCount == 1);
+					assert(std::holds_alternative<ExpressionType>(*parameters));
 
-						return VectorType {
-							componentCount, std::get<PrimitiveType>(exprType)
-						};
-					}
+					const ExpressionType& exprType = std::get<ExpressionType>(*parameters);
+					assert(IsPrimitiveType(exprType));
+
+					return VectorType {
+						componentCount, std::get<PrimitiveType>(exprType)
+					};
 				}
 			});
 		}
@@ -2256,6 +2257,35 @@ namespace nzsl::Ast
 				targetArrayType.SetupInnerType(std::move(innerType));
 
 				targetType = std::move(targetArrayType);
+			}
+		}
+		else if (IsImplicitMatrixType(targetType))
+		{
+			std::optional<PrimitiveType> innerType;
+			for (std::size_t i = 0; i < castExpr.expressions.size(); ++i)
+			{
+				const ExpressionType* exprType = GetResolvedExpressionType(MandatoryExpr(castExpr.expressions[i], castExpr.sourceLocation), true);
+				if (!exprType)
+					break;
+
+				if (IsMatrixType(*exprType))
+					innerType = std::get<MatrixType>(*exprType).type;
+				else if (IsVectorType(*exprType))
+					innerType = std::get<VectorType>(*exprType).type;
+				else if (IsPrimitiveType(*exprType))
+					innerType = std::get<PrimitiveType>(*exprType);
+
+				if (innerType && !IsLiteralType(*innerType))
+					break; //< continue if literal type as we could encounter a non-literal type later (e.g. vec3(1, u32(2), 3))
+			}
+
+			if (innerType)
+			{
+				const ImplicitMatrixType& implicitMatrixType = std::get<ImplicitMatrixType>(targetType);
+				std::size_t columnCount = implicitMatrixType.columnCount;
+				std::size_t rowCount = implicitMatrixType.rowCount;
+
+				targetType = MatrixType{ columnCount, rowCount, *innerType };
 			}
 		}
 		else if (IsImplicitVectorType(targetType))

--- a/src/NZSL/GlslWriter.cpp
+++ b/src/NZSL/GlslWriter.cpp
@@ -724,6 +724,11 @@ namespace nzsl
 		throw std::runtime_error("unexpected ImplicitArrayType");
 	}
 
+	void GlslWriter::Append(const Ast::ImplicitMatrixType& /*type*/)
+	{
+		throw std::runtime_error("unexpected ImplicitMatrixType");
+	}
+
 	void GlslWriter::Append(const Ast::ImplicitVectorType& /*type*/)
 	{
 		throw std::runtime_error("unexpected ImplicitVectorType");

--- a/src/NZSL/GlslWriter.cpp
+++ b/src/NZSL/GlslWriter.cpp
@@ -719,9 +719,14 @@ namespace nzsl
 		throw std::runtime_error("unexpected FunctionType");
 	}
 
+	void GlslWriter::Append(const Ast::ImplicitArrayType& /*type*/)
+	{
+		throw std::runtime_error("unexpected ImplicitArrayType");
+	}
+
 	void GlslWriter::Append(const Ast::ImplicitVectorType& /*type*/)
 	{
-		throw std::runtime_error("unexpected DeducedVectorType");
+		throw std::runtime_error("unexpected ImplicitVectorType");
 	}
 
 	void GlslWriter::Append(Ast::InterpolationQualifier interpolation)

--- a/src/NZSL/LangWriter.cpp
+++ b/src/NZSL/LangWriter.cpp
@@ -300,9 +300,14 @@ namespace nzsl
 		throw std::runtime_error("unexpected function type");
 	}
 
+	void LangWriter::Append(const Ast::ImplicitArrayType& /*vecType*/)
+	{
+		throw std::runtime_error("unexpected ImplicitVectorType");
+	}
+
 	void LangWriter::Append(const Ast::ImplicitVectorType& /*vecType*/)
 	{
-		throw std::runtime_error("unexpected DeducedVectorType");
+		throw std::runtime_error("unexpected ImplicitVectorType");
 	}
 
 	void LangWriter::Append(const Ast::IntrinsicFunctionType& /*functionType*/)

--- a/src/NZSL/LangWriter.cpp
+++ b/src/NZSL/LangWriter.cpp
@@ -300,9 +300,14 @@ namespace nzsl
 		throw std::runtime_error("unexpected function type");
 	}
 
-	void LangWriter::Append(const Ast::ImplicitArrayType& /*vecType*/)
+	void LangWriter::Append(const Ast::ImplicitArrayType& /*arrayType*/)
 	{
 		throw std::runtime_error("unexpected ImplicitVectorType");
+	}
+
+	void LangWriter::Append(const Ast::ImplicitMatrixType& /*matrixType*/)
+	{
+		throw std::runtime_error("unexpected ImplicitMatrixType");
 	}
 
 	void LangWriter::Append(const Ast::ImplicitVectorType& /*vecType*/)

--- a/tests/src/Tests/ImplicitTests.cpp
+++ b/tests/src/Tests/ImplicitTests.cpp
@@ -6,7 +6,63 @@
 
 TEST_CASE("implicit", "[Shader]")
 {
-	SECTION("Literal primitives")
+	SECTION("Implicit primitives")
+	{
+		ResolveOptions resolveOpt;
+		resolveOpt.literalOptions = &ResolveOptions::defaultLiteralOptions;
+
+		std::string_view nzslSource = R"(
+[nzsl_version("1.1")]
+module;
+
+[entry(frag)]
+fn foo()
+{
+	let x: f32;
+	let v = vec3(x, x, x); // no need to write vec3[f32](x, x, x)
+}
+)";
+
+		nzsl::Ast::ModulePtr shaderModule = nzsl::Parse(nzslSource);
+		ResolveModule(*shaderModule, resolveOpt);
+
+		ExpectGLSL(*shaderModule, R"(
+void main()
+{
+	float x;
+	vec3 v = vec3(x, x, x);
+})");
+
+		ExpectNZSL(*shaderModule, R"(
+[entry(frag)]
+fn foo()
+{
+	let x: f32;
+	let v: vec3[f32] = vec3[f32](x, x, x);
+}
+)");
+
+		ExpectSPIRV(*shaderModule, R"(
+ %1 = OpTypeVoid
+ %2 = OpTypeFunction %1
+ %3 = OpTypeFloat 32
+ %4 = OpTypePointer StorageClass(Function) %3
+ %5 = OpTypeVector %3 3
+ %6 = OpTypePointer StorageClass(Function) %5
+ %7 = OpFunction %1 FunctionControl(0) %2
+ %8 = OpLabel
+ %9 = OpVariable %4 StorageClass(Function)
+%10 = OpVariable %6 StorageClass(Function)
+%11 = OpLoad %3 %9
+%12 = OpLoad %3 %9
+%13 = OpLoad %3 %9
+%14 = OpCompositeConstruct %5 %11 %12 %13
+      OpStore %10 %14
+      OpReturn
+      OpFunctionEnd)", {}, {}, true);
+	}
+
+	SECTION("Implicit arrays")
 	{
 		ResolveOptions resolveOpt;
 		resolveOpt.literalOptions = &ResolveOptions::defaultLiteralOptions;
@@ -28,9 +84,6 @@ const c = array(true, false, false);
 [entry(frag)]
 fn foo()
 {
-	let x: f32;
-	let v = vec3(x, x, x); // no need to write vec3[f32](x, x, x)
-	
 	let value = vec3(-1, -3, 42);
 	let runtimeArray = array(value, value, vec3(1, 2, 3));
 }
@@ -62,8 +115,6 @@ bool c[3] = bool[3](
 );
 void main()
 {
-	float x;
-	vec3 v = vec3(x, x, x);
 	ivec3 value = ivec3(-1, -3, 42);
 	ivec3 runtimeArray[3] = ivec3[3](value, value, ivec3(1, 2, 3));
 })");
@@ -96,8 +147,6 @@ const c: array[bool, 3] = array[bool, 3](
 [entry(frag)]
 fn foo()
 {
-	let x: f32;
-	let v: vec3[f32] = vec3[f32](x, x, x);
 	let value: vec3[i32] = vec3[i32](-1, -3, 42);
 	let runtimeArray: array[vec3[i32], 3] = array[vec3[i32], 3](value, value, vec3[i32](1, 2, 3));
 }
@@ -151,35 +200,200 @@ fn foo()
 %48 = OpConstantComposite %44 %46 %47 %47
 %50 = OpTypeVoid
 %51 = OpTypeFunction %50
-%52 = OpTypePointer StorageClass(Function) %1
-%53 = OpTypeVector %1 3
-%54 = OpTypePointer StorageClass(Function) %53
-%55 = OpConstant %16 i32(-1)
-%56 = OpConstant %16 i32(-3)
-%57 = OpConstant %16 i32(42)
-%58 = OpConstantComposite %17 %55 %56 %57
-%59 = OpTypePointer StorageClass(Function) %17
-%60 = OpTypePointer StorageClass(Function) %18
+%52 = OpConstant %16 i32(-1)
+%53 = OpConstant %16 i32(-3)
+%54 = OpConstant %16 i32(42)
+%55 = OpConstantComposite %17 %52 %53 %54
+%56 = OpTypePointer StorageClass(Function) %17
+%57 = OpTypePointer StorageClass(Function) %18
 %15 = OpVariable %6 StorageClass(Private) %14
 %33 = OpVariable %19 StorageClass(Private) %32
 %42 = OpVariable %6 StorageClass(Private) %41
 %49 = OpVariable %45 StorageClass(Private) %48
-%61 = OpFunction %50 FunctionControl(0) %51
-%62 = OpLabel
-%63 = OpVariable %52 StorageClass(Function)
-%64 = OpVariable %54 StorageClass(Function)
-%65 = OpVariable %59 StorageClass(Function)
-%66 = OpVariable %60 StorageClass(Function)
-%67 = OpLoad %1 %63
-%68 = OpLoad %1 %63
-%69 = OpLoad %1 %63
-%70 = OpCompositeConstruct %53 %67 %68 %69
-      OpStore %64 %70
-      OpStore %65 %58
-%71 = OpLoad %17 %65
-%72 = OpLoad %17 %65
-%73 = OpCompositeConstruct %18 %71 %72 %23
-      OpStore %66 %73
+%58 = OpFunction %50 FunctionControl(0) %51
+%59 = OpLabel
+%60 = OpVariable %56 StorageClass(Function)
+%61 = OpVariable %57 StorageClass(Function)
+      OpStore %60 %55
+%62 = OpLoad %17 %60
+%63 = OpLoad %17 %60
+%64 = OpCompositeConstruct %18 %62 %63 %23
+      OpStore %61 %64
+      OpReturn
+      OpFunctionEnd)", {}, {}, true);
+	}
+
+	SECTION("Implicit matrices")
+	{
+		ResolveOptions resolveOpt;
+		resolveOpt.literalOptions = &ResolveOptions::defaultLiteralOptions;
+
+		std::string_view nzslSource = R"(
+[nzsl_version("1.1")]
+[feature(float64)]
+module;
+
+[entry(frag)]
+fn foo()
+{
+	let x: f32 = 1.0;
+	let v = vec3[f64](-2.0, -1.0, 0.0);
+
+	let m1 = mat4(x);
+	let m2 = mat3(m1);
+	let m3 = mat2(x, x, x, x);
+	let m4 = mat3(v, vec3(1.0, 2.0, 3.0), vec3(4.0, 5.0, 6.0));
+}
+)";
+
+		nzsl::Ast::ModulePtr shaderModule = nzsl::Parse(nzslSource);
+		ResolveModule(*shaderModule, resolveOpt);
+
+		// We need GLSL 4.0 for fp64
+		nzsl::GlslWriter::Environment glslEnv;
+		glslEnv.glMajorVersion = 4;
+		glslEnv.glMinorVersion = 0;
+		glslEnv.glES = false;
+
+		ExpectGLSL(*shaderModule, R"(
+void main()
+{
+	float x = 1.0;
+	dvec3 v = dvec3(-2.0lf, -1.0lf, 0.0lf);
+	mat4 m1 = mat4(x);
+	mat3 m2 = mat3(m1);
+	mat2 m3 = mat2(x, x, x, x);
+	dmat3 m4 = dmat3(v, dvec3(1.0lf, 2.0lf, 3.0lf), dvec3(4.0lf, 5.0lf, 6.0lf));
+})", {}, glslEnv);
+
+		ExpectNZSL(*shaderModule, R"(
+[entry(frag)]
+fn foo()
+{
+	let x: f32 = 1.0;
+	let v: vec3[f64] = vec3[f64](-2.0, -1.0, 0.0);
+	let m1: mat4[f32] = mat4[f32](x);
+	let m2: mat3[f32] = mat3[f32](m1);
+	let m3: mat2[f32] = mat2[f32](x, x, x, x);
+	let m4: mat3[f64] = mat3[f64](v, vec3[f64](1.0, 2.0, 3.0), vec3[f64](4.0, 5.0, 6.0));
+}
+)");
+
+		ExpectSPIRV(*shaderModule, R"(
+ %1 = OpTypeVoid
+ %2 = OpTypeFunction %1
+ %3 = OpTypeFloat 32
+ %4 = OpConstant %3 f32(1)
+ %5 = OpTypePointer StorageClass(Function) %3
+ %6 = OpTypeFloat 64
+ %7 = OpConstant %6 f64(-2)
+ %8 = OpConstant %6 f64(-1)
+ %9 = OpConstant %6 f64(0)
+%10 = OpTypeVector %6 3
+%11 = OpTypePointer StorageClass(Function) %10
+%12 = OpTypeVector %3 4
+%13 = OpTypeMatrix %12 4
+%14 = OpTypePointer StorageClass(Function) %13
+%15 = OpTypeInt 32 0
+%16 = OpConstant %15 u32(0)
+%17 = OpConstant %3 f32(0)
+%18 = OpConstant %15 u32(1)
+%19 = OpConstant %15 u32(2)
+%20 = OpConstant %15 u32(3)
+%21 = OpTypeVector %3 3
+%22 = OpTypeMatrix %21 3
+%23 = OpTypePointer StorageClass(Function) %22
+%24 = OpTypeInt 32 1
+%25 = OpConstant %24 i32(0)
+%26 = OpConstant %24 i32(1)
+%27 = OpConstant %24 i32(2)
+%28 = OpTypeVector %3 2
+%29 = OpTypeMatrix %28 2
+%30 = OpTypePointer StorageClass(Function) %29
+%31 = OpTypeMatrix %10 3
+%32 = OpTypePointer StorageClass(Function) %31
+%33 = OpConstant %6 f64(1)
+%34 = OpConstant %6 f64(2)
+%35 = OpConstant %6 f64(3)
+%36 = OpConstantComposite %10 %33 %34 %35
+%37 = OpConstant %6 f64(4)
+%38 = OpConstant %6 f64(5)
+%39 = OpConstant %6 f64(6)
+%40 = OpConstantComposite %10 %37 %38 %39
+%57 = OpTypePointer StorageClass(Function) %12
+%72 = OpTypePointer StorageClass(Function) %21
+%86 = OpTypePointer StorageClass(Function) %28
+%41 = OpFunction %1 FunctionControl(0) %2
+%42 = OpLabel
+%43 = OpVariable %5 StorageClass(Function)
+%44 = OpVariable %11 StorageClass(Function)
+%45 = OpVariable %14 StorageClass(Function)
+%46 = OpVariable %14 StorageClass(Function)
+%47 = OpVariable %23 StorageClass(Function)
+%48 = OpVariable %23 StorageClass(Function)
+%49 = OpVariable %30 StorageClass(Function)
+%50 = OpVariable %30 StorageClass(Function)
+%51 = OpVariable %32 StorageClass(Function)
+%52 = OpVariable %32 StorageClass(Function)
+      OpStore %43 %4
+%53 = OpCompositeConstruct %10 %7 %8 %9
+      OpStore %44 %53
+%54 = OpLoad %3 %43
+%55 = OpCompositeConstruct %12 %54 %17 %17 %17
+%56 = OpAccessChain %57 %45 %16
+      OpStore %56 %55
+%58 = OpLoad %3 %43
+%59 = OpCompositeConstruct %12 %17 %58 %17 %17
+%60 = OpAccessChain %57 %45 %18
+      OpStore %60 %59
+%61 = OpLoad %3 %43
+%62 = OpCompositeConstruct %12 %17 %17 %61 %17
+%63 = OpAccessChain %57 %45 %19
+      OpStore %63 %62
+%64 = OpLoad %3 %43
+%65 = OpCompositeConstruct %12 %17 %17 %17 %64
+%66 = OpAccessChain %57 %45 %20
+      OpStore %66 %65
+%67 = OpLoad %13 %45
+      OpStore %46 %67
+%68 = OpAccessChain %57 %46 %16
+%69 = OpLoad %12 %68
+%70 = OpVectorShuffle %21 %69 %69 0 1 2
+%71 = OpAccessChain %72 %47 %16
+      OpStore %71 %70
+%73 = OpAccessChain %57 %46 %18
+%74 = OpLoad %12 %73
+%75 = OpVectorShuffle %21 %74 %74 0 1 2
+%76 = OpAccessChain %72 %47 %18
+      OpStore %76 %75
+%77 = OpAccessChain %57 %46 %19
+%78 = OpLoad %12 %77
+%79 = OpVectorShuffle %21 %78 %78 0 1 2
+%80 = OpAccessChain %72 %47 %19
+      OpStore %80 %79
+%81 = OpLoad %22 %47
+      OpStore %48 %81
+%82 = OpLoad %3 %43
+%83 = OpLoad %3 %43
+%84 = OpCompositeConstruct %28 %82 %83
+%85 = OpAccessChain %86 %49 %16
+      OpStore %85 %84
+%87 = OpLoad %3 %43
+%88 = OpLoad %3 %43
+%89 = OpCompositeConstruct %28 %87 %88
+%90 = OpAccessChain %86 %49 %18
+      OpStore %90 %89
+%91 = OpLoad %29 %49
+      OpStore %50 %91
+%92 = OpLoad %10 %44
+%93 = OpAccessChain %11 %51 %16
+      OpStore %93 %92
+%94 = OpAccessChain %11 %51 %18
+      OpStore %94 %36
+%95 = OpAccessChain %11 %51 %19
+      OpStore %95 %40
+%96 = OpLoad %31 %51
+      OpStore %52 %96
       OpReturn
       OpFunctionEnd)", {}, {}, true);
 	}

--- a/tests/src/Tests/ImplicitTests.cpp
+++ b/tests/src/Tests/ImplicitTests.cpp
@@ -15,7 +15,7 @@ TEST_CASE("implicit", "[Shader]")
 [nzsl_version("1.1")]
 module;
 
-const vertPos = array[vec2[f32]](
+const vertPos = array( //< no neet to set array type
 	vec2[f32](-1.0, 1.0),
 	vec2(-1.0, -3.0), //< no need to write vec2[f32] for every value
 	vec2( 3.0, 1.0)
@@ -28,7 +28,7 @@ fn foo()
 	let v = vec3(x, x, x); // no need to write vec3[f32](x, x, x)
 	
 	let value = vec3(-1, -3, 42);
-	let runtimeArray = array[vec3[i32]](value, value, vec3(1, 2, 3));
+	let runtimeArray = array(value, value, vec3(1, 2, 3));
 }
 )";
 

--- a/tests/src/Tests/ImplicitTests.cpp
+++ b/tests/src/Tests/ImplicitTests.cpp
@@ -21,6 +21,10 @@ const vertPos = array( //< no neet to set array type
 	vec2( 3.0, 1.0)
 );
 
+const a = array(vec3(1, 2, 3), vec3(4, 5, 6), vec3(7, 8, 9));
+const b = array(vec2(1.0, 2.0), vec2(3.0, 4.0), vec2(5.0, 6.0));
+const c = array(true, false, false);
+
 [entry(frag)]
 fn foo()
 {
@@ -41,6 +45,21 @@ vec2 vertPos[3] = vec2[3](
 	vec2(-1.0, -3.0),
 	vec2(3.0, 1.0)
 );
+ivec3 a[3] = ivec3[3](
+	ivec3(1, 2, 3),
+	ivec3(4, 5, 6),
+	ivec3(7, 8, 9)
+);
+vec2 b[3] = vec2[3](
+	vec2(1.0, 2.0),
+	vec2(3.0, 4.0),
+	vec2(5.0, 6.0)
+);
+bool c[3] = bool[3](
+	true,
+	false,
+	false
+);
 void main()
 {
 	float x;
@@ -54,6 +73,24 @@ const vertPos: array[vec2[f32], 3] = array[vec2[f32], 3](
 	vec2[f32](-1.0, 1.0),
 	vec2[f32](-1.0, -3.0),
 	vec2[f32](3.0, 1.0)
+);
+
+const a: array[vec3[i32], 3] = array[vec3[i32], 3](
+	vec3[i32](1, 2, 3),
+	vec3[i32](4, 5, 6),
+	vec3[i32](7, 8, 9)
+);
+
+const b: array[vec2[f32], 3] = array[vec2[f32], 3](
+	vec2[f32](1.0, 2.0),
+	vec2[f32](3.0, 4.0),
+	vec2[f32](5.0, 6.0)
+);
+
+const c: array[bool, 3] = array[bool, 3](
+	true,
+	false,
+	false
 );
 
 [entry(frag)]
@@ -81,41 +118,68 @@ fn foo()
 %12 = OpConstant %1 f32(3)
 %13 = OpConstantComposite %2 %12 %8
 %14 = OpConstantComposite %5 %9 %11 %13
-%16 = OpTypeVoid
-%17 = OpTypeFunction %16
-%18 = OpTypePointer StorageClass(Function) %1
-%19 = OpTypeVector %1 3
-%20 = OpTypePointer StorageClass(Function) %19
-%21 = OpTypeInt 32 1
-%22 = OpTypeVector %21 3
-%23 = OpConstant %21 i32(-1)
-%24 = OpConstant %21 i32(-3)
-%25 = OpConstant %21 i32(42)
-%26 = OpConstantComposite %22 %23 %24 %25
-%27 = OpTypePointer StorageClass(Function) %22
-%28 = OpConstant %21 i32(1)
-%29 = OpConstant %21 i32(2)
-%30 = OpConstant %21 i32(3)
-%31 = OpConstantComposite %22 %28 %29 %30
-%32 = OpTypeArray %22 %4
-%33 = OpTypePointer StorageClass(Function) %32
+%16 = OpTypeInt 32 1
+%17 = OpTypeVector %16 3
+%18 = OpTypeArray %17 %4
+%19 = OpTypePointer StorageClass(Private) %18
+%20 = OpConstant %16 i32(1)
+%21 = OpConstant %16 i32(2)
+%22 = OpConstant %16 i32(3)
+%23 = OpConstantComposite %17 %20 %21 %22
+%24 = OpConstant %16 i32(4)
+%25 = OpConstant %16 i32(5)
+%26 = OpConstant %16 i32(6)
+%27 = OpConstantComposite %17 %24 %25 %26
+%28 = OpConstant %16 i32(7)
+%29 = OpConstant %16 i32(8)
+%30 = OpConstant %16 i32(9)
+%31 = OpConstantComposite %17 %28 %29 %30
+%32 = OpConstantComposite %18 %23 %27 %31
+%34 = OpConstant %1 f32(2)
+%35 = OpConstantComposite %2 %8 %34
+%36 = OpConstant %1 f32(4)
+%37 = OpConstantComposite %2 %12 %36
+%38 = OpConstant %1 f32(5)
+%39 = OpConstant %1 f32(6)
+%40 = OpConstantComposite %2 %38 %39
+%41 = OpConstantComposite %5 %35 %37 %40
+%43 = OpTypeBool
+%44 = OpTypeArray %43 %4
+%45 = OpTypePointer StorageClass(Private) %44
+%46 = OpConstantTrue %43
+%47 = OpConstantFalse %43
+%48 = OpConstantComposite %44 %46 %47 %47
+%50 = OpTypeVoid
+%51 = OpTypeFunction %50
+%52 = OpTypePointer StorageClass(Function) %1
+%53 = OpTypeVector %1 3
+%54 = OpTypePointer StorageClass(Function) %53
+%55 = OpConstant %16 i32(-1)
+%56 = OpConstant %16 i32(-3)
+%57 = OpConstant %16 i32(42)
+%58 = OpConstantComposite %17 %55 %56 %57
+%59 = OpTypePointer StorageClass(Function) %17
+%60 = OpTypePointer StorageClass(Function) %18
 %15 = OpVariable %6 StorageClass(Private) %14
-%34 = OpFunction %16 FunctionControl(0) %17
-%35 = OpLabel
-%36 = OpVariable %18 StorageClass(Function)
-%37 = OpVariable %20 StorageClass(Function)
-%38 = OpVariable %27 StorageClass(Function)
-%39 = OpVariable %33 StorageClass(Function)
-%40 = OpLoad %1 %36
-%41 = OpLoad %1 %36
-%42 = OpLoad %1 %36
-%43 = OpCompositeConstruct %19 %40 %41 %42
-      OpStore %37 %43
-      OpStore %38 %26
-%44 = OpLoad %22 %38
-%45 = OpLoad %22 %38
-%46 = OpCompositeConstruct %32 %44 %45 %31
-      OpStore %39 %46
+%33 = OpVariable %19 StorageClass(Private) %32
+%42 = OpVariable %6 StorageClass(Private) %41
+%49 = OpVariable %45 StorageClass(Private) %48
+%61 = OpFunction %50 FunctionControl(0) %51
+%62 = OpLabel
+%63 = OpVariable %52 StorageClass(Function)
+%64 = OpVariable %54 StorageClass(Function)
+%65 = OpVariable %59 StorageClass(Function)
+%66 = OpVariable %60 StorageClass(Function)
+%67 = OpLoad %1 %63
+%68 = OpLoad %1 %63
+%69 = OpLoad %1 %63
+%70 = OpCompositeConstruct %53 %67 %68 %69
+      OpStore %64 %70
+      OpStore %65 %58
+%71 = OpLoad %17 %65
+%72 = OpLoad %17 %65
+%73 = OpCompositeConstruct %18 %71 %72 %23
+      OpStore %66 %73
       OpReturn
       OpFunctionEnd)", {}, {}, true);
 	}


### PR DESCRIPTION
Close #16 
```rs
let x: f32;
let a = array(x, x, x); // a is an array[f32, 3]

let x: f32 = 1.0;
let v = vec3[f64](-2.0, -1.0, 0.0);

let m1 = mat4(x);
let m2 = mat3(m1);
let m3 = mat2(x, x, x, x);
let m4 = mat3(v, vec3(1.0, 2.0, 3.0), vec3(4.0, 5.0, 6.0));
```