### PR TITLE
Add rgba16f, rgba32f and rgba8_snorm storage image formats

### DIFF
--- a/src/NZSL/Ast/Transformations/ResolveTransformer.cpp
+++ b/src/NZSL/Ast/Transformations/ResolveTransformer.cpp
@@ -899,8 +899,8 @@ namespace nzsl::Ast
 							throw CompilerTextureUnexpectedFormatError{ sourceLocation, "<TODO>" };
 
 						ImageFormat format = static_cast<ImageFormat>(std::get<std::uint32_t>(formatValue));
-						if (format != ImageFormat::RGBA8) //< TODO: Add support for more formats
-							throw CompilerTextureUnexpectedFormatError{ sourceLocation, "<TODO>" };
+						if (LangData::s_imageFormats.find(format) == LangData::s_imageFormats.end())
+							throw CompilerTextureUnexpectedFormatError{ sourceLocation, std::to_string(Nz::SafeCast<std::uint32_t>(format)) };
 
 						formatOpt = format;
 					}

--- a/src/NZSL/GlslWriter.cpp
+++ b/src/NZSL/GlslWriter.cpp
@@ -2640,9 +2640,10 @@ namespace nzsl
 				const Ast::TextureType& textureType = std::get<Ast::TextureType>(exprType);
 				if (textureType.format != ImageFormat::Unknown)
 				{
-					assert(textureType.format == ImageFormat::RGBA8);
+					auto formatIt = LangData::s_imageFormats.find(textureType.format);
+					assert(formatIt != LangData::s_imageFormats.end());
 					BeginLayout();
-					Append("rgba8");
+					Append(formatIt->second.identifier);
 				}
 			}
 

--- a/src/NZSL/Lang/LangData.hpp
+++ b/src/NZSL/Lang/LangData.hpp
@@ -80,8 +80,23 @@ namespace nzsl::LangData
 		{ "readwrite", { 1, Nz::SafeCast<std::uint32_t>(AccessPolicy::ReadWrite) } },
 		{ "writeonly", { 2, Nz::SafeCast<std::uint32_t>(AccessPolicy::WriteOnly) } },
 
-		// TODO: Register more image formats
-		{ "rgba8", { 3, Nz::SafeCast<std::uint32_t>(ImageFormat::RGBA8) }}
+		// TODO: Register more image formats (integer and narrow ones, see s_imageFormats)
+		{ "rgba8", { 3, Nz::SafeCast<std::uint32_t>(ImageFormat::RGBA8) }},
+		{ "rgba8_snorm", { 4, Nz::SafeCast<std::uint32_t>(ImageFormat::RGBA8Snorm) }},
+		{ "rgba16f", { 5, Nz::SafeCast<std::uint32_t>(ImageFormat::RGBA16f) }},
+		{ "rgba32f", { 6, Nz::SafeCast<std::uint32_t>(ImageFormat::RGBA32f) }}
+	});
+
+	struct ImageFormatData
+	{
+		std::string_view identifier;
+	};
+
+	constexpr auto s_imageFormats = frozen::make_unordered_map<ImageFormat, ImageFormatData>({
+		{ ImageFormat::RGBA8,      { "rgba8" } },
+		{ ImageFormat::RGBA8Snorm, { "rgba8_snorm" } },
+		{ ImageFormat::RGBA16f,    { "rgba16f" } },
+		{ ImageFormat::RGBA32f,    { "rgba32f" } },
 	});
 
 	struct DepthWriteModeData

--- a/src/NZSL/LangWriter.cpp
+++ b/src/NZSL/LangWriter.cpp
@@ -446,8 +446,9 @@ namespace nzsl
 
 		if (textureType.format != ImageFormat::Unknown)
 		{
-			assert(textureType.format == ImageFormat::RGBA8); //< TODO
-			Append(", rgba8");
+			auto formatIt = LangData::s_imageFormats.find(textureType.format);
+			assert(formatIt != LangData::s_imageFormats.end());
+			Append(", ", formatIt->second.identifier);
 		}
 		Append("]");
 	}

--- a/src/NZSL/SpirV/SpirvConstantCache.cpp
+++ b/src/NZSL/SpirV/SpirvConstantCache.cpp
@@ -1108,11 +1108,14 @@ namespace nzsl
 		{
 			switch (type.format)
 			{
+				// Keep in sync with LangData::s_imageFormats
 				case ImageFormat::Unknown: return SpirvImageFormat::Unknown;
 				case ImageFormat::RGBA8: return SpirvImageFormat::Rgba8;
+				case ImageFormat::RGBA8Snorm: return SpirvImageFormat::Rgba8Snorm;
+				case ImageFormat::RGBA16f: return SpirvImageFormat::Rgba16f;
 				case ImageFormat::RGBA32f: return SpirvImageFormat::Rgba32f;
 				default:
-					throw std::runtime_error("<TODO>");
+					throw std::runtime_error("unsupported image format");
 			}
 		}();
 

--- a/tests/src/Tests/ComputeTests.cpp
+++ b/tests/src/Tests/ComputeTests.cpp
@@ -227,4 +227,63 @@ fn main(input: Input)
       OpReturn
       OpFunctionEnd)", {}, {}, true);
 	}
+
+	SECTION("Storage image formats")
+	{
+		std::string_view nzslSource = R"(
+[nzsl_version("1.1")]
+module;
+
+[auto_binding]
+external
+{
+	tex_rgba16f: texture2D[f32, writeonly, rgba16f],
+	tex_rgba32f: texture2D[f32, writeonly, rgba32f],
+	tex_rgba8_snorm: texture2D[f32, writeonly, rgba8_snorm]
+}
+
+struct Input
+{
+	[builtin(global_invocation_indices)] indices: vec3[u32]
+}
+
+[entry(compute)]
+[workgroup(8, 8, 1)]
+fn main(input: Input)
+{
+	let coords = vec2[i32](input.indices.xy);
+	let value = vec4[f32](1.0, 0.0, 0.0, 1.0);
+	tex_rgba16f.Write(coords, value);
+	tex_rgba32f.Write(coords, value);
+	tex_rgba8_snorm.Write(coords, value);
+}
+)";
+
+		nzsl::Ast::ModulePtr shaderModule = nzsl::Parse(nzslSource);
+		ResolveModule(*shaderModule);
+
+		nzsl::GlslWriter::Environment glslEnv;
+		glslEnv.glES = true;
+		glslEnv.glMajorVersion = 3;
+		glslEnv.glMinorVersion = 1;
+
+		ExpectGLSL(*shaderModule, R"(
+layout(rgba16f) uniform writeonly image2D tex_rgba16f;
+layout(rgba32f) uniform writeonly image2D tex_rgba32f;
+layout(rgba8_snorm) uniform writeonly image2D tex_rgba8_snorm;
+)", {}, glslEnv);
+
+		ExpectNZSL(*shaderModule, R"(
+	[set(0), binding(0)] tex_rgba16f: texture2D[f32, writeonly, rgba16f],
+	[set(0), binding(1)] tex_rgba32f: texture2D[f32, writeonly, rgba32f],
+	[set(0), binding(2)] tex_rgba8_snorm: texture2D[f32, writeonly, rgba8_snorm]
+)");
+
+		ExpectSPIRV(*shaderModule, R"(
+ %2 = OpTypeImage %1 Dim(Dim2D) 2 0 0 2 ImageFormat(Rgba16f)
+ %3 = OpTypePointer StorageClass(UniformConstant) %2
+ %5 = OpTypeImage %1 Dim(Dim2D) 2 0 0 2 ImageFormat(Rgba32f)
+ %6 = OpTypePointer StorageClass(UniformConstant) %5
+ %8 = OpTypeImage %1 Dim(Dim2D) 2 0 0 2 ImageFormat(Rgba8Snorm))", {}, {}, true);
+	}
 }


### PR DESCRIPTION
Scope is limited to four-component float formats that require no extra SPIR-V capability, so Read and Write keep operating on vec4.

Formats were hardcoded in five places; LangData::s_imageFormats is now the single source of truth for validation and for both writers.